### PR TITLE
Fix missing language code bug

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -53,7 +53,7 @@ class I18n {
   middleware () {
     return (ctx, next) => {
       const session = this.config.sessionName && ctx[this.config.sessionName]
-      const languageCode = (session && session.__language_code) || (ctx.from && ctx.from.language_code)
+      const languageCode = (session && session.__language_code) || (ctx.from && ctx.from.language_code) || this.config.defaultLanguage
       ctx.i18n = this.createContext(languageCode, {
         from: ctx.from,
         chat: ctx.chat


### PR DESCRIPTION
If is no saved language code in the session and if missing ctx.from (for example, channel_post update type)
```
TypeError: Cannot read property 'split' of undefined  
|     at pluralize (/app/node_modules/telegraf-i18n/lib/pluralize.js:38:32)  
|     at I18nContext.t (/app/node_modules/telegraf-i18n/lib/context.js:36:18)
```