### PR TITLE
fix: adapt match function to return true/false instead of the text

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -95,7 +95,7 @@ function compileTemplates (root) {
 }
 
 I18n.match = function (resourceKey, templateData) {
-  return (text, ctx) => (text && ctx && ctx.i18n && text === ctx.i18n.t(resourceKey, templateData)) ? [text] : null
+  return (text, ctx) => text && ctx && ctx.i18n && text === ctx.i18n.t(resourceKey, templateData)
 }
 
 module.exports = I18n


### PR DESCRIPTION
You provided this example in your readme in order to work with localized keyboards:
```js
const { match } = require('telegraf-i18n')

// In case you use custom keyboard with localized labels.
bot.hears(match('keyboard.foo'), (ctx) => ...)
```

This does not work for me. I tried to analyze the reason for it. Your match function returns a function which returns an array with the text in it, it should match in the given language of ctx of the first function. That array would be correct if directly supplied but not with the indirect function. The function should return true or false when matched or not.

So i removed the ternary operator and it worked for me. Please check again why this was made the way it was. Maybe an older version of Telegraf supported this way? Or did I made an error somewhere else?
