### PR TITLE
fix: select locale en for en-US

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -16,7 +16,7 @@ class I18nContext {
     const code = languageCode.toLowerCase()
     const shortCode = code.split('-')[0]
 
-    if (!this.repository[code] || !this.repository[shortCode]) {
+    if (!this.repository[code] && !this.repository[shortCode]) {
       this.languageCode = this.config.defaultLanguage
       this.shortLanguageCode = this.languageCode.split('-')[0]
       return


### PR DESCRIPTION
if default locale is `ru`
you have `ru.yaml` and `en.yaml`, and locale is en-US always selects default locale