### PR TITLE
Added types for locale method

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -19,6 +19,7 @@ declare module 'telegraf-i18n' {
         t (languageCode?: string, resourceKey?: string, templateData?: object): string;
         t (resourceKey?: string, templateData?: object): string;
         locale (): string;
+        locale (languageCode?: string): void;
     }
 
     export default I18n;


### PR DESCRIPTION
Type signature for locale method with a parameter was missing. Here it comes.