### PR TITLE
Allow skipping pluralize

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -38,7 +38,7 @@ class I18nContext {
       if (!this.config.allowMissing) {
         throw new Error(`telegraf-i18n: '${this.languageCode}.${resourceKey}' not found`)
       }
-      f (this.config.fallbackToDefaultLanguage) {
+      if (this.config.fallbackToDefaultLanguage) {
         template = this.getTemplate(this.config.defaultLanguage, resourceKey)
       } else {
         template = () => resourceKey

--- a/lib/context.js
+++ b/lib/context.js
@@ -38,7 +38,11 @@ class I18nContext {
       if (!this.config.allowMissing) {
         throw new Error(`telegraf-i18n: '${this.languageCode}.${resourceKey}' not found`)
       }
-      template = () => resourceKey
+      f (this.config.fallbackToDefaultLanguage) {
+        template = this.getTemplate(this.config.defaultLanguage, resourceKey)
+      } else {
+        template = () => resourceKey
+      }
     }
     if (this.config.skipPluralize) {
       return template(Object.assign(this.defaultContext, context))

--- a/lib/context.js
+++ b/lib/context.js
@@ -40,9 +40,13 @@ class I18nContext {
       }
       template = () => resourceKey
     }
-    return template(Object.assign({
-      pluralize: pluralize(this.shortLanguageCode)
-    }, this.defaultContext, context))
+    if (this.config.skipPluralize) {
+      return template(Object.assign(this.defaultContext, context))
+    } else {
+      return template(Object.assign({
+        pluralize: pluralize(this.shortLanguageCode)
+      }, this.defaultContext, context))
+    }
   }
 }
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,6 +5,7 @@ declare module 'telegraf-i18n' {
         sessionName: string;
         allowMissing: boolean;
         defaultLanguage: string;
+        skipPluralize: boolean;
     }
 
     type ContextUpdate = (ctx: any, next?: (() => any) | undefined) => any;


### PR DESCRIPTION
Here's the deal: when we try to use the `t` function, `pluralize` functionality is trying to be created. When locale is unsupported by pluralize, it logs an error to the console. This option to skip pluralize will help some of us who don't need `pluralize` functionality but do need the support of, for example, `ua`, `ch` or `hi` languages.

Also, we can add an option to fallback to the default message instead of simply sending the keys.