### PR TITLE
Add analysis helper for translations 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -51,6 +51,11 @@ class I18n {
     }
   }
 
+  resourceKeys (languageCode) {
+    const language = languageCode.toLowerCase()
+    return getTemplateKeysRecursive(this.repository[language])
+  }
+
   middleware () {
     return (ctx, next) => {
       const session = this.config.useSession && ctx[this.config.sessionName]
@@ -92,6 +97,20 @@ function compileTemplates (root) {
     }
   })
   return root
+}
+
+function getTemplateKeysRecursive (root, prefix = '') {
+  let keys = []
+  for (const key of Object.keys(root)) {
+    const subKey = prefix ? prefix + '.' + key : key
+    if (typeof root[key] === 'object') {
+      keys = keys.concat(getTemplateKeysRecursive(root[key], subKey))
+    } else {
+      keys.push(subKey)
+    }
+  }
+
+  return keys
 }
 
 I18n.match = function (resourceKey, templateData) {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -56,6 +56,18 @@ class I18n {
     return getTemplateKeysRecursive(this.repository[language])
   }
 
+  missingKeys (languageOfInterest, referenceLanguage = this.config.defaultLanguage) {
+    const interest = this.resourceKeys(languageOfInterest)
+    const reference = this.resourceKeys(referenceLanguage)
+
+    return reference
+      .filter(o => !interest.includes(o))
+  }
+
+  overspecifiedKeys (languageOfInterest, referenceLanguage = this.config.defaultLanguage) {
+    return this.missingKeys(referenceLanguage, languageOfInterest)
+  }
+
   middleware () {
     return (ctx, next) => {
       const session = this.config.useSession && ctx[this.config.sessionName]

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -68,6 +68,13 @@ class I18n {
     return this.missingKeys(referenceLanguage, languageOfInterest)
   }
 
+  translationProgress (languageOfInterest, referenceLanguage = this.config.defaultLanguage) {
+    const reference = this.resourceKeys(referenceLanguage).length
+    const missing = this.missingKeys(languageOfInterest, referenceLanguage).length
+
+    return (reference - missing) / reference
+  }
+
   middleware () {
     return (ctx, next) => {
       const session = this.config.useSession && ctx[this.config.sessionName]

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -51,6 +51,10 @@ class I18n {
     }
   }
 
+  availableLocales () {
+    return Object.keys(this.repository)
+  }
+
   resourceKeys (languageCode) {
     const language = languageCode.toLowerCase()
     return getTemplateKeysRecursive(this.repository[language])

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,6 +14,7 @@ declare module 'telegraf-i18n' {
         loadLocales (directory: string): void;
         loadLocale (languageCode: string, i18Data: object): void;
         resetLocale (languageCode: string): void;
+        resourceKeys (languageCode: string): string[];
         middleware(): ContextUpdate;
         createContext (languageCode: string, templateData: object): void;
         t (languageCode?: string, resourceKey?: string, templateData?: object): string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -15,6 +15,8 @@ declare module 'telegraf-i18n' {
         loadLocale (languageCode: string, i18Data: object): void;
         resetLocale (languageCode: string): void;
         resourceKeys (languageCode: string): string[];
+        missingKeys (languageOfInterest: string, referenceLanguage?: string): string[];
+        overspecifiedKeys (languageOfInterest: string, referenceLanguage?: string): string[];
         middleware(): ContextUpdate;
         createContext (languageCode: string, templateData: object): void;
         t (languageCode?: string, resourceKey?: string, templateData?: object): string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -14,6 +14,7 @@ declare module 'telegraf-i18n' {
         loadLocales (directory: string): void;
         loadLocale (languageCode: string, i18Data: object): void;
         resetLocale (languageCode: string): void;
+        availableLocales (): string[];
         resourceKeys (languageCode: string): string[];
         missingKeys (languageOfInterest: string, referenceLanguage?: string): string[];
         overspecifiedKeys (languageOfInterest: string, referenceLanguage?: string): string[];

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,6 +17,7 @@ declare module 'telegraf-i18n' {
         resourceKeys (languageCode: string): string[];
         missingKeys (languageOfInterest: string, referenceLanguage?: string): string[];
         overspecifiedKeys (languageOfInterest: string, referenceLanguage?: string): string[];
+        translationProgress (languageOfInterest: string, referenceLanguage?: string): number;
         middleware(): ContextUpdate;
         createContext (languageCode: string, templateData: object): void;
         t (languageCode?: string, resourceKey?: string, templateData?: object): string;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "telegraf": "^3.7.1"
   },
   "devDependencies": {
-    "ava": "^0.25.0",
+    "ava": "^1.3.1",
     "eslint": "^5.4.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-ava": "^5.1.0",

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -32,7 +32,7 @@ test('resourceKeys with depth', t => {
   ])
 })
 
-function createMultiLanguageExample() {
+function createMultiLanguageExample () {
   const i18n = new I18n()
   i18n.loadLocale('en', {
     greeting: 'Hello!',

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -1,0 +1,33 @@
+const test = require('ava')
+
+const I18n = require('../lib/i18n.js')
+
+test('resourceKeys flat', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    greeting: 'Hello!'
+  })
+
+  t.deepEqual(i18n.resourceKeys('en'), [
+    'greeting'
+  ])
+})
+
+test('resourceKeys with depth', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    greeting: 'Hello!',
+    foo: {
+      bar: '42',
+      hell: {
+        devil: 666
+      }
+    }
+  })
+
+  t.deepEqual(i18n.resourceKeys('en'), [
+    'greeting',
+    'foo.bar',
+    'foo.hell.devil'
+  ])
+})

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -31,3 +31,31 @@ test('resourceKeys with depth', t => {
     'foo.hell.devil'
   ])
 })
+
+function createMultiLanguageExample() {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    greeting: 'Hello!',
+    checkout: 'Thank you!'
+  })
+  i18n.loadLocale('ru', {
+    greeting: 'Привет!'
+  })
+  return i18n
+}
+
+test('missingKeys ', t => {
+  const i18n = createMultiLanguageExample()
+  t.deepEqual(i18n.missingKeys('en', 'ru'), [])
+  t.deepEqual(i18n.missingKeys('ru'), [
+    'checkout'
+  ])
+})
+
+test('overspecifiedKeys', t => {
+  const i18n = createMultiLanguageExample()
+  t.deepEqual(i18n.overspecifiedKeys('ru'), [])
+  t.deepEqual(i18n.overspecifiedKeys('en', 'ru'), [
+    'checkout'
+  ])
+})

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -59,3 +59,13 @@ test('overspecifiedKeys', t => {
     'checkout'
   ])
 })
+
+test('translationProgress', t => {
+  const i18n = createMultiLanguageExample()
+
+  // 'checkout' is missing
+  t.is(i18n.translationProgress('ru'), 0.5)
+
+  // Overspecified (unneeded 'checkout') but everything required is there
+  t.deepEqual(i18n.translationProgress('en', 'ru'), 1)
+})

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -44,6 +44,14 @@ function createMultiLanguageExample () {
   return i18n
 }
 
+test('availableLocales', t => {
+  const i18n = createMultiLanguageExample()
+  t.deepEqual(i18n.availableLocales(), [
+    'en',
+    'ru'
+  ])
+})
+
 test('missingKeys ', t => {
   const i18n = createMultiLanguageExample()
   t.deepEqual(i18n.missingKeys('en', 'ru'), [])

--- a/test/basics.js
+++ b/test/basics.js
@@ -1,0 +1,20 @@
+const test = require('ava')
+
+const I18n = require('../lib/i18n.js')
+
+test('can translate', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    greeting: 'Hello!'
+  })
+  t.is(i18n.t('en', 'greeting'), 'Hello!')
+})
+
+test('allowMissing false throws', t => {
+  const i18n = new I18n({
+    allowMissing: false
+  })
+  t.throws(() => {
+    i18n.t('en', 'greeting')
+  }, 'telegraf-i18n: \'en.greeting\' not found')
+})

--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,5 +1,0 @@
-const test = require('ava')
-
-test('', (t) => {
-  t.pass()
-})


### PR DESCRIPTION
When using the translations I would like to see the status of it.
For example what is still missing in translation files (`missingKeys `). (How much of it is translated yet: `translationProgress`)
Also translations that are in specific files but not in the main, default language (forgotten to delete) are interesting (`overspecifiedKeys `).

With that I am able to easily create Ava test cases like this one:
```js
for (const lang of i18n.availableLocales()) {
  test(`locale ${lang} is not overspecified`, t => {
    t.deepEqual(i18n.overspecifiedKeys(lang), [])
  })
}
```

Also adds basic test cases for I18n in general.