### PR TITLE
fix: don't throw error on not existing locale

### DIFF
--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -57,7 +57,7 @@ class I18n {
 
   resourceKeys (languageCode) {
     const language = languageCode.toLowerCase()
-    return getTemplateKeysRecursive(this.repository[language])
+    return getTemplateKeysRecursive(this.repository[language] || {})
   }
 
   missingKeys (languageOfInterest, referenceLanguage = this.config.defaultLanguage) {

--- a/test/analyse-language-repository.js
+++ b/test/analyse-language-repository.js
@@ -32,6 +32,15 @@ test('resourceKeys with depth', t => {
   ])
 })
 
+test('resourceKeys of not existing locale are empty', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    greeting: 'Hello!'
+  })
+
+  t.deepEqual(i18n.resourceKeys('de'), [])
+})
+
 function createMultiLanguageExample () {
   const i18n = new I18n()
   i18n.loadLocale('en', {


### PR DESCRIPTION
Checking status of a not existing locale shouldn't result in errors. They are simply empty.