### PR TITLE
 ✨ Add functional forms support

### DIFF
--- a/lib/pluralize.js
+++ b/lib/pluralize.js
@@ -60,7 +60,7 @@ module.exports = function pluralize (languageCode) {
     const form = forms[pluralRules[key](number)]
     
     if (typeof form === 'function') {
-      return forms[pluralRules[key](number)](number)
+      return form(number)
     }
     
     return `${number} ${form}`

--- a/lib/pluralize.js
+++ b/lib/pluralize.js
@@ -56,13 +56,13 @@ module.exports = function pluralize (languageCode) {
       console.warn(`i18n::Pluralize: Unsupported language ${languageCode}`)
       key = 'english'
     }
-    
+
     const form = forms[pluralRules[key](number)]
-    
+
     if (typeof form === 'function') {
       return form(number)
     }
-    
+
     return `${number} ${form}`
   }
 }

--- a/lib/pluralize.js
+++ b/lib/pluralize.js
@@ -56,6 +56,13 @@ module.exports = function pluralize (languageCode) {
       console.warn(`i18n::Pluralize: Unsupported language ${languageCode}`)
       key = 'english'
     }
-    return `${number} ${forms[pluralRules[key](number)]}`
+    
+    const form = forms[pluralRules[key](number)]
+    
+    if (typeof form === 'function') {
+      return forms[pluralRules[key](number)](number)
+    }
+    
+    return `${number} ${form}`
   }
 }

--- a/test/pluralize.js
+++ b/test/pluralize.js
@@ -1,0 +1,25 @@
+const test = require('ava')
+
+const I18n = require('../lib/i18n.js')
+
+test('can pluralize', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    // eslint-disable-next-line no-template-curly-in-string
+    pluralize: "${pluralize(n, 'There was an apple', 'There were apples')}"
+  })
+  t.is(i18n.t('en', 'pluralize', { n: 0 }), '0 There were apples')
+  t.is(i18n.t('en', 'pluralize', { n: 1 }), '1 There was an apple')
+  t.is(i18n.t('en', 'pluralize', { n: 5 }), '5 There were apples')
+})
+
+test('can pluralize using functional forms', t => {
+  const i18n = new I18n()
+  i18n.loadLocale('en', {
+    // eslint-disable-next-line no-template-curly-in-string
+    pluralize: "${pluralize(n, n => 'There was an apple', n => 'There were ' + n + ' apples')}"
+  })
+  t.is(i18n.t('en', 'pluralize', { n: 0 }), 'There were 0 apples')
+  t.is(i18n.t('en', 'pluralize', { n: 1 }), 'There was an apple')
+  t.is(i18n.t('en', 'pluralize', { n: 5 }), 'There were 5 apples')
+})


### PR DESCRIPTION
Add ability to call pluralize with functions as forms instead of strings
```pluralize(n, n => 'There was an apple', n => 'There were ' + n + ' apples')```
Now you can insert the number to the any part of form, not only to the beginning